### PR TITLE
api authentication is accepted for get_activity method

### DIFF
--- a/app/controllers/tt_completer_controller.rb
+++ b/app/controllers/tt_completer_controller.rb
@@ -1,6 +1,6 @@
 class TtCompleterController < ApplicationController
   before_filter :js_auth, :authorize_global
-  accept_api_auth :get_issue, :get_issue_id, :get_issue_subject
+  accept_api_auth :get_issue, :get_issue_id, :get_issue_subject, :get_activity
 
   include TimeTrackersHelper
 


### PR DESCRIPTION
Without this change usage of get_activity.json method on other parts of the plugin causes the browser to display a Redmine API login window.
